### PR TITLE
Clean shortcuts icon section

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,10 +46,8 @@ app.get("/:actions/manifest.json", (request, response) => {
       url: `/${request.params.actions}/launch?url=${url}`,
       icons: [
         {
-          src: "images/ic_launcher-96.png",
-          sizes: "96x96",
-          purpose: "any",
-          type: "image/png",
+          src: "images/ic_launcher.png",
+          sizes: "192x192",
         },
       ],
     };


### PR DESCRIPTION
As documented in https://web.dev/app-shortcuts/#define-app-shortcuts-in-the-web-app-manifest,
- `purpose` is not a shortcut icon member,
- `type` is optional,
- recommended size is 192x192, not 96x96.

This PR fixes these nits.
Those changes should also be applied to the blog post: https://paul.kinlan.me/creating-a-quick-launcher-for-android-using-the-web/. See https://github.com/PaulKinlan/paul.kinlan.me/pull/27

@PaulKinlan 